### PR TITLE
Fix aws_args expansion on macOS, prevent metadata override

### DIFF
--- a/lib/rollback.bash
+++ b/lib/rollback.bash
@@ -40,7 +40,7 @@ function rollback_lambda() {
   case "${deployment_result}" in
   "failed")
     log_header ":lambda: Deployment failed, performing rollback"
-    if ! perform_rollback "${function_name}" "${alias_name}" "${previous_version}" "${current_version}" "${aws_args[@]}"; then
+    if ! perform_rollback "${function_name}" "${alias_name}" "${previous_version}" "${current_version}" "${aws_args[@]+${aws_args[@]}}"; then
       log_error "Rollback failed"
       create_rollback_failed_annotation "${function_name}" "${alias_name}" "${current_version}" "${previous_version}"
       return 1
@@ -58,7 +58,7 @@ function rollback_lambda() {
     log_warning "Unknown deployment result: ${deployment_result}"
     if [[ -n "${current_version}" && -n "${previous_version}" ]]; then
       log_header ":lambda: Performing manual rollback"
-      if ! perform_rollback "${function_name}" "${alias_name}" "${previous_version}" "${current_version}" "${aws_args[@]}"; then
+      if ! perform_rollback "${function_name}" "${alias_name}" "${previous_version}" "${current_version}" "${aws_args[@]+${aws_args[@]}}"; then
         log_error "Manual rollback failed"
         create_rollback_failed_annotation "${function_name}" "${alias_name}" "${current_version}" "${previous_version}"
         return 1
@@ -94,7 +94,7 @@ function perform_rollback() {
 
   # Update alias to point to previous version
   if ! aws lambda update-alias \
-    "${aws_args[@]}" \
+    "${aws_args[@]+${aws_args[@]}}" \
     --function-name "${function_name}" \
     --name "${alias_name}" \
     --function-version "${rollback_version}"; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -198,17 +198,17 @@ teardown() {
   # Override the buildkite-agent stub for this test
   unstub buildkite-agent || true
   stub buildkite-agent \
-    "meta-data exists deployment:aws_lambda:result : exit 0" \
-    "meta-data get deployment:aws_lambda:result : echo success" \
-    "meta-data exists deployment:aws_lambda:current_version : exit 0" \
-    "meta-data get deployment:aws_lambda:current_version : echo 2" \
-    "meta-data exists deployment:aws_lambda:previous_version : exit 0" \
-    "meta-data get deployment:aws_lambda:previous_version : echo 1" \
-    "meta-data exists deployment:aws_lambda:previous_arn : exit 0" \
-    "meta-data get deployment:aws_lambda:previous_arn : echo arn:aws:lambda:us-east-1:123456789012:function:test-function:1" \
-    "meta-data exists deployment:aws_lambda:auto_rollback : exit 1" \
-    "meta-data exists deployment:aws_lambda:package_type : exit 0" \
-    "meta-data get deployment:aws_lambda:package_type : echo Zip" \
+    "meta-data exists deployment:aws_lambda:test-function:result : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:result : echo success" \
+    "meta-data exists deployment:aws_lambda:test-function:current_version : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:current_version : echo 2" \
+    "meta-data exists deployment:aws_lambda:test-function:previous_version : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:previous_version : echo 1" \
+    "meta-data exists deployment:aws_lambda:test-function:previous_arn : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:previous_arn : echo arn:aws:lambda:us-east-1:123456789012:function:test-function:1" \
+    "meta-data exists deployment:aws_lambda:test-function:auto_rollback : exit 1" \
+    "meta-data exists deployment:aws_lambda:test-function:package_type : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:package_type : echo Zip" \
     "annotate --style success --context lambda-deployment * : echo Annotation created"
 
   stub aws \
@@ -228,14 +228,14 @@ teardown() {
   # Override the buildkite-agent stub for this test
   unstub buildkite-agent || true
   stub buildkite-agent \
-    "meta-data exists deployment:aws_lambda:result : exit 0" \
-    "meta-data get deployment:aws_lambda:result : echo failure" \
-    "meta-data exists deployment:aws_lambda:current_version : exit 0" \
-    "meta-data get deployment:aws_lambda:current_version : echo 2" \
-    "meta-data exists deployment:aws_lambda:previous_version : exit 0" \
-    "meta-data get deployment:aws_lambda:previous_version : echo 1" \
-    "meta-data exists deployment:aws_lambda:auto_rollback : exit 0" \
-    "meta-data get deployment:aws_lambda:auto_rollback : echo true" \
+    "meta-data exists deployment:aws_lambda:test-function:result : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:result : echo failure" \
+    "meta-data exists deployment:aws_lambda:test-function:current_version : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:current_version : echo 2" \
+    "meta-data exists deployment:aws_lambda:test-function:previous_version : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:previous_version : echo 1" \
+    "meta-data exists deployment:aws_lambda:test-function:auto_rollback : exit 0" \
+    "meta-data get deployment:aws_lambda:test-function:auto_rollback : echo true" \
     "annotate --style success --context lambda-deployment * : echo Annotation created"
 
   stub aws \


### PR DESCRIPTION
Issues addressed:
* Fix `unbound variable` for `aws_args` on default macOS Bash
* Fix metadata keys clash when deploying multiple Lambda functions (add function name in the key)
* Improve annotations for deployment (include function name, version info, alias, strategy, and more) aligning with existing rollback annotation