### PR TITLE
Add missing examples to the README

### DIFF
--- a/examples/deploy-container.yml
+++ b/examples/deploy-container.yml
@@ -1,0 +1,20 @@
+steps:
+  - label: ":rocket: Deploy Lambda container"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-container-function"
+          alias: "production"
+          mode: "deploy"
+          package-type: "Image"
+          image-uri: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-function:${BUILDKITE_BUILD_NUMBER}"
+          region: "us-east-1"
+          timeout: 300
+          memory-size: 512
+          description: "Container deployment from build ${BUILDKITE_BUILD_NUMBER}"
+          environment:
+            STAGE: "production"
+            VERSION: "${BUILDKITE_BUILD_NUMBER}"
+          auto-rollback: true
+          health-check-enabled: true
+          health-check-payload: '{"length": 5, "width": 10}'
+          health-check-timeout: 120

--- a/examples/deploy-s3.yml
+++ b/examples/deploy-s3.yml
@@ -1,0 +1,30 @@
+steps:
+  - label ":rocket: Deploy Lambda from S3"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-s3-function"
+          alias: "production"
+          mode: "deploy"
+          s3-bucket: "my-lambda-deployments"
+          s3-key: "releases/${BUILDKITE_BUILD_NUMBER}/function.zip"
+          region: "us-east-1"
+          runtime: "nodejs18.x"
+          handler: "index.handler"
+          timeout: 60
+          memory-size: 256
+          description: "S3 deployment from build ${BUILDKITE_BUILD_NUMBER}"
+          environment:
+            NODE_ENV: "production"
+            BUILD_NUMBER: "${BUILDKITE_BUILD_NUMBER}"
+          auto-rollback: true
+          health-check-enabled: true
+
+  - block: ":thinking_face: Review deployment"
+
+  - label: ":leftwards_arrow_with_hook: Rollback if needed"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-s3-function"
+          alias: "production"
+          mode: "rollback"
+          region: "us-east-1"

--- a/examples/deploy-zip-file.yml
+++ b/examples/deploy-zip-file.yml
@@ -1,0 +1,28 @@
+steps:
+  - label: ":package: Build function"
+    command: |
+      echo "Building Lambda function..."
+      # Your build commands here
+      zip -r function.zip src/
+    
+  - label: ":rocket: Deploy Lambda"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-function"
+          alias: "production"
+          mode: "deploy"
+          zip-file: "function.zip"
+          region: "us-east-1"
+          runtime: "python3.13"
+          handler: "lambda_function.lambda_handler"
+          timeout: 30
+          memory-size: 128
+          description: "Deployed from build ${BUILDKITE_BUILD_NUMBER}"
+          environment:
+            LOG_LEVEL: "INFO"
+            STAGE: "production"
+          auto-rollback: true
+          health-check-enabled: true
+          health-check-timeout: 60
+          health-check-payload: '{"test": true}'
+

--- a/examples/manual-rollback.yml
+++ b/examples/manual-rollback.yml
@@ -1,0 +1,25 @@
+steps:
+  - label: ":rocket: Deploy Lambda (no auto-rollback)"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-function"
+          alias: "production"
+          mode: "deploy"
+          zip-file: "function.zip"
+          region: "us-east-1"
+          runtime: "python3.13"
+          handler: "lambda_function.lambda_handler"
+          timeout: 30
+          memory-size: 128
+          description: "Deployment from build ${BUILDKITE_BUILD_NUMBER}"
+
+  - block: ":thinking_face: Review deployment"
+    prompt: "Check if the deployment is working correctly"
+
+  - label: ":leftwards_arrow_with_hook: Manual rollback"
+    plugins:
+      - aws-lambda-deploy#v1.0.0:
+          function-name: "my-function"
+          alias: "production"
+          mode: "rollback"
+          region: "us-east-1"


### PR DESCRIPTION
Add missing pipeline examples linked in the README.md.
Also, simplify README itself.